### PR TITLE
Fix: Resolve TypeError in TimelineItem due to missing todo.state

### DIFF
--- a/src/components/Timeline/TimelineComponent.tsx
+++ b/src/components/Timeline/TimelineComponent.tsx
@@ -4,10 +4,10 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { categorizeDate, getTimeframeSortOrder } from "@/lib/date-util";
 import todoFetchRequest from "@/requests/todoFetchRequest";
-import { Todo } from "@prisma/client";
+import { TodoWithColumn } from "@/types/todo"; // Import TodoWithColumn
 import dayjs from "dayjs";
 // Update import from react-query to @tanstack/react-query
-import { useQuery } from "@tanstack/react-query"; 
+import { useQuery } from "@tanstack/react-query";
 import VerticalTimelineSection from "./VerticalTimelineSection";
 import { VerticalTimelineSkeleton } from "./VerticalTimelineSkeleton";
 import { useToast } from "../ui/use-toast"; // Import useToast
@@ -22,9 +22,9 @@ const TimelineComponent = () => {
 
   // Update useQuery syntax for v4+
   // Include projectId and view in the queryKey to refetch when they change
-  const { data: todos, isLoading, error } = useQuery<Todo[], Error>({
+  const { data: todos, isLoading, error } = useQuery<TodoWithColumn[], Error>({ // Use TodoWithColumn[]
     queryKey: ["todos", { projectId, view }], // Query key includes projectId and view
-    queryFn: () => todoFetchRequest(projectId, view), // Pass projectId and view to fetch function
+    queryFn: () => todoFetchRequest(projectId, view) as Promise<TodoWithColumn[]>, // Assert type here
     onError: (err) => {
       console.error("Error fetching todos for timeline:", err);
       // Show toast on error
@@ -39,7 +39,7 @@ const TimelineComponent = () => {
   // Group tasks only if todos exist and are not empty
   const groupedTasks =
     todos && todos.length > 0
-      ? todos.reduce((groups: Record<string, Todo[]>, task) => {
+      ? todos.reduce((groups: Record<string, TodoWithColumn[]>, task) => { // Use TodoWithColumn[] for groups
           const date = dayjs(task.createdAt);
           const timeframe = categorizeDate(date);
 
@@ -47,10 +47,10 @@ const TimelineComponent = () => {
             groups[timeframe] = [];
           }
           // Sort tasks within each group by creation date (newest first)
-          groups[timeframe].push(task);
+          groups[timeframe].push(task); // task is TodoWithColumn
           groups[timeframe].sort((a, b) => dayjs(b.createdAt).unix() - dayjs(a.createdAt).unix());
           return groups;
-        }, {}) 
+        }, {} as Record<string, TodoWithColumn[]>) // Initialize with correct type
       : {}; // Default to empty object if no todos
 
   if (isLoading) {

--- a/src/components/Timeline/TimelineItem.tsx
+++ b/src/components/Timeline/TimelineItem.tsx
@@ -3,7 +3,8 @@ import { getLabelColor } from "@/lib/color";
 import { getRelativeTimeString } from "@/lib/date-util";
 import { cn } from "@/lib/utils";
 import { openTodoEditor } from "@/redux/actions/todoEditorAction";
-import { Todo } from "@prisma/client";
+import { State } from "@/lib/types/prisma-types"; // Import the State enum
+import { TodoWithColumn, EmbeddedProjectColumn } from "@/types/todo"; // Use TodoWithColumn
 import dayjs from "dayjs";
 import {
   BarChart2,
@@ -17,53 +18,81 @@ import { FC } from "react";
 import { useDispatch } from "react-redux";
 
 type TimelineItemProps = {
-  todo: Todo;
+  todo: TodoWithColumn; // Use TodoWithColumn
   isLast?: boolean;
+};
+
+// Helper function to map column name to State enum value
+const mapColumnNameToState = (columnName?: string | null): State => {
+  if (!columnName) {
+    return State.TODO; // Default state if no column or column name
+  }
+  switch (columnName.toUpperCase().replace(/\s+/g, "_")) {
+    case "TO_DO":
+    case "TODO":
+      return State.TODO;
+    case "IN_PROGRESS":
+    case "IN PROGRESS": // Common variation
+      return State.IN_PROGRESS;
+    case "REVIEW":
+      return State.REVIEW;
+    case "DONE":
+      return State.DONE;
+    default:
+      console.warn(`Unknown column name: ${columnName}, defaulting to TODO`);
+      return State.TODO; // Fallback for unknown column names
+  }
 };
 
 const TimelineItem: FC<TimelineItemProps> = ({ todo, isLast = false }) => {
   const dispatch = useDispatch();
+
+  const derivedState = mapColumnNameToState(todo.column?.name);
 
   const dueDate = todo.deadline ? dayjs(todo.deadline) : null;
   const createdDate = dayjs(todo.createdAt);
 
   // Determine if task is overdue
   const isOverdue = !!dueDate && createdDate.isAfter(dueDate);
-  const isFinished = todo.state === "DONE" || todo.state === "REVIEW";
+  const isFinished = derivedState === State.DONE || derivedState === State.REVIEW;
 
   // Get the appropriate icon based on task status
-  const getStatusIcon = (state: Todo["state"]) => {
+  const getStatusIcon = (state: State) => { // Parameter type is now State enum
     switch (state) {
-      case "TODO":
+      case State.TODO:
         return <Settings className="h-5 w-5" />;
-      case "IN_PROGRESS":
+      case State.IN_PROGRESS:
         return <BarChart2 className="h-5 w-5" />;
-      case "REVIEW":
+      case State.REVIEW:
         return <Clock className="h-5 w-5" />;
-      case "DONE":
+      case State.DONE:
         return <CheckCircle className="h-5 w-5" />;
       default:
-        return <Settings className="h-5 w-5" />;
+        return <Settings className="h-5 w-5" />; // Should not happen with enum
     }
   };
 
   // Get the appropriate color based on task status
-  const getStatusColor = (state: Todo["state"]) => {
+  const getStatusColor = (state: State) => { // Parameter type is now State enum
     switch (state) {
-      case "TODO":
+      case State.TODO:
         return "bg-blue-500 text-white";
-      case "IN_PROGRESS":
+      case State.IN_PROGRESS:
         return "bg-amber-500 text-white";
-      case "REVIEW":
+      case State.REVIEW:
         return "bg-purple-500 text-white";
-      case "DONE":
+      case State.DONE:
         return "bg-green-500 text-white";
       default:
+        // Should not happen with enum, but provide a fallback just in case
         return "bg-gray-500 text-white";
     }
   };
 
   const handleClick = () => {
+    // Ensure the todo object passed to openTodoEditor is the original one,
+    // or if it expects a plain Todo, we might need to strip the column if it causes issues.
+    // For now, assuming it can handle the TodoWithColumn structure.
     dispatch(openTodoEditor(todo, "/timeline", "edit"));
   };
 
@@ -83,10 +112,10 @@ const TimelineItem: FC<TimelineItemProps> = ({ todo, isLast = false }) => {
           <div
             className={cn(
               "flex items-center justify-center w-10 h-10 rounded-full z-0",
-              getStatusColor(todo.state),
+              getStatusColor(derivedState), // Use derivedState
             )}
           >
-            {getStatusIcon(todo.state)}
+            {getStatusIcon(derivedState)} {/* Use derivedState */}
           </div>
           {!isLast && (
             <div className="w-0.5 h-full bg-border absolute top-10 bottom-0 left-1/2 -translate-x-1/2" />
@@ -106,17 +135,17 @@ const TimelineItem: FC<TimelineItemProps> = ({ todo, isLast = false }) => {
                   variant="outline"
                   className={cn(
                     "capitalize",
-                    todo.state === "TODO" &&
+                    derivedState === State.TODO &&
                       "bg-blue-500/10 text-blue-500 border-blue-500/20",
-                    todo.state === "IN_PROGRESS" &&
+                    derivedState === State.IN_PROGRESS &&
                       "bg-amber-500/10 text-amber-500 border-amber-500/20",
-                    todo.state === "REVIEW" &&
+                    derivedState === State.REVIEW &&
                       "bg-purple-500/10 text-purple-500 border-purple-500/20",
-                    todo.state === "DONE" &&
+                    derivedState === State.DONE &&
                       "bg-green-500/10 text-green-500 border-green-500/20",
                   )}
                 >
-                  {todo.state.replace("_", " ")}
+                  {derivedState.replace("_", " ")} {/* Use derivedState */}
                 </Badge>
               </div>
 

--- a/src/components/Timeline/VerticalTimelineSection.tsx
+++ b/src/components/Timeline/VerticalTimelineSection.tsx
@@ -1,13 +1,13 @@
 import { TIMEFRAMECOLOR } from "@/lib/const";
 import { cn } from "@/lib/utils";
-import { Todo } from "@prisma/client";
+import { TodoWithColumn } from "@/types/todo"; // Import TodoWithColumn
 import { FC } from "react";
 import TimelineItem from "./TimelineItem";
 import dayjs from "dayjs";
 
 type VerticalTimelineSectionProps = {
   title: string;
-  todos: Todo[];
+  todos: TodoWithColumn[]; // Use TodoWithColumn[]
 };
 
 const VerticalTimelineSection: FC<VerticalTimelineSectionProps> = ({
@@ -16,9 +16,13 @@ const VerticalTimelineSection: FC<VerticalTimelineSectionProps> = ({
 }) => {
   if (todos.length === 0) return null;
 
-  const sortedTodos = todos.toSorted(
-    (a, b) => dayjs(b.createdAt).unix() - dayjs(a.createdAt).unix(),
-  );
+  // Sorting is already done in TimelineComponent's reduce step,
+  // but if it needs to be ensured or done differently here, it can be.
+  // For now, assuming todos are correctly sorted as passed.
+  // const sortedTodos = todos.toSorted(
+  // (a, b) => dayjs(b.createdAt).unix() - dayjs(a.createdAt).unix(),
+  // );
+  // Using 'todos' directly as they should be pre-sorted.
 
   return (
     <div className="mb-8">
@@ -35,10 +39,11 @@ const VerticalTimelineSection: FC<VerticalTimelineSectionProps> = ({
       </div>
 
       <div className="space-y-0">
-        {sortedTodos.map((todo, index) => (
+        {/* Using 'todos' directly as sortedTodos was commented out */}
+        {todos.map((todo, index) => (
           <TimelineItem
             key={todo.id}
-            todo={todo}
+            todo={todo} // todo is now TodoWithColumn
             isLast={index === todos.length - 1}
           />
         ))}


### PR DESCRIPTION
- The `state` field was removed from the `Todo` model in prisma.schema.
- Updated `TimelineItem.tsx` to derive task state from `todo.column.name`.
- Implemented a helper function `mapColumnNameToState` to convert column names (e.g., "To Do", "In Progress") to the `State` enum values required by the component's logic.
- Added fallbacks for todos without a column or with unrecognized column names, defaulting to `State.TODO`.
- Updated prop types in `TimelineComponent.tsx`, `VerticalTimelineSection.tsx`, and `TimelineItem.tsx` from `Todo` to `TodoWithColumn` to ensure type consistency and reflect that `column` data is expected and used.